### PR TITLE
Fix auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 func main() {
 
 	bot := Bot{
-		Name:            "techtrans",
+		Nick:            "techtrans",
 		CredentialsPath: "./credentials.json",
 		Port:            "6667",
 		Server:          "irc.chat.twitch.tv",

--- a/twitch_bot.go
+++ b/twitch_bot.go
@@ -22,8 +22,8 @@ type OAuthCredentials struct {
 }
 
 type Bot struct {
-	// Name the bot goes by
-	Name string
+	// Twitch username (login name) in lowercase
+	Nick string
 
 	// Path to a json file containing the bot's OAuth credentials
 	CredentialsPath string
@@ -109,10 +109,10 @@ func (bot *Bot) JoinChannel() {
 	Inform("Attempting to join #%s...", bot.Channel)
 
 	bot.connection.Write([]byte("PASS oauth:" + bot.credentials.Password + "\r\n"))
-	bot.connection.Write([]byte("NICK " + bot.Name + "\r\n"))
+	bot.connection.Write([]byte("NICK " + bot.Nick + "\r\n"))
 	bot.connection.Write([]byte("JOIN #" + bot.Channel + "\r\n"))
 
-	Inform("Joined #%s as @%s!", bot.Channel, bot.Name)
+	Inform("Joined #%s as @%s!", bot.Channel, bot.Nick)
 }
 
 // Read from the private credentials json file

--- a/twitch_bot.go
+++ b/twitch_bot.go
@@ -108,8 +108,8 @@ func (bot *Bot) Disconnect() {
 func (bot *Bot) JoinChannel() {
 	Inform("Attempting to join #%s...", bot.Channel)
 
+	bot.connection.Write([]byte("PASS oauth:" + bot.credentials.Password + "\r\n"))
 	bot.connection.Write([]byte("NICK " + bot.Name + "\r\n"))
-	bot.connection.Write([]byte("PASS " + bot.credentials.Password + "\r\n"))
 	bot.connection.Write([]byte("JOIN #" + bot.Channel + "\r\n"))
 
 	Inform("Joined #%s as @%s!", bot.Channel, bot.Name)


### PR DESCRIPTION
Add `oauth:` before password, and rename `Name` to `Nick` (to match Twitch IRC documentation).

Now able to read messages!

```
You are in a maze of twisty passages, all alike.
```

close #25, close #2. close #3